### PR TITLE
Adapt to renaming package `cryptol-verifier` to `cryptol-saw-core`.

### DIFF
--- a/jvm-verifier.cabal
+++ b/jvm-verifier.cabal
@@ -51,7 +51,7 @@ library
     , vector >= 0.7
     , saw-core
     , saw-core-aig
-    , cryptol-verifier
+    , cryptol-saw-core
 
   hs-source-dirs: src
 


### PR DESCRIPTION
Adapt to GaloisInc/saw-core#62.